### PR TITLE
ci: adopt central web-release.yml@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  id-token: write       # OIDC for build-provenance attestation
+  attestations: write   # write the provenance attestation
 jobs:
   release:
     uses: fjacquet/ci/.github/workflows/web-release.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: fjacquet/ci/.github/workflows/web-release.yml@v1
+    with:
+      node-version: "24"
+      publish-npm: false
+      publish-docker: false
+      build-dir: "dist"


### PR DESCRIPTION
Adopts the shared reusable release workflow for this repo (previously had no release workflow).

## What this adds
- New \`.github/workflows/release.yml\` triggered on \`v*\` tag pushes.
- Delegates to \`fjacquet/ci/.github/workflows/web-release.yml@v1\`.
- Produces a GitHub Release with \`dist\` archives and a CycloneDX SBOM.
- Node 24; npm and Docker publishing disabled.

## Usage
Push a \`vX.Y.Z\` tag to cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)